### PR TITLE
UI/UX: Improve view selector tabs and rename workspaces to realms

### DIFF
--- a/client/src/components/LinksView.jsx
+++ b/client/src/components/LinksView.jsx
@@ -64,7 +64,7 @@ export default function LinksView({ isGreatest = false }) {
     <div className="links-view">
       {!currentWorkspace ? (
         <div className="no-workspace">
-          <p>Please create or select a workspace first</p>
+          <p>Please create or select a realm first</p>
         </div>
       ) : (
         <>

--- a/client/src/components/Sidebar.css
+++ b/client/src/components/Sidebar.css
@@ -21,6 +21,7 @@
   letter-spacing: 0.5px;
   border-radius: var(--radius);
   transition: all var(--transition-fast);
+  color: var(--text-primary);
 }
 
 .workspace-dropdown:hover {
@@ -37,41 +38,50 @@
 
 .view-selector {
   display: flex;
-  padding: 0 var(--space-sm);
-  gap: 0;
+  padding: var(--space-xs);
+  gap: var(--space-xs);
   border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.view-selector::-webkit-scrollbar {
+  display: none;
 }
 
 .view-btn {
-  flex: 1;
-  padding: var(--space-sm) 0;
+  flex-shrink: 0;
+  padding: var(--space-xs) var(--space-md);
   font-size: var(--font-size-xs);
   font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  text-transform: capitalize;
+  letter-spacing: 0.3px;
   color: var(--text-secondary);
   background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
+  border: 1px solid transparent;
   transition: all var(--transition-fast);
   text-align: center;
-  border-radius: 0;
+  border-radius: var(--radius);
+  white-space: nowrap;
 }
 
 .view-btn:hover {
   color: var(--text-primary);
   background: var(--bg-tertiary);
+  border-color: var(--border);
 }
 
 .view-btn.active {
-  color: var(--text-primary);
-  border-bottom-color: var(--accent);
+  color: var(--accent);
+  background: var(--bg-tertiary);
+  border-color: var(--accent);
   font-weight: 600;
 }
 
 .view-btn:focus-visible {
-  box-shadow: inset var(--focus-ring);
-  border-radius: var(--radius) var(--radius) 0 0;
+  box-shadow: var(--focus-ring);
+  outline: none;
 }
 
 .channels-section, .links-section {

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -43,7 +43,7 @@ export default function Sidebar({ view, setView }) {
       setShowWorkspaceModal(false);
     } catch (error) {
       console.error('Failed to create workspace:', error);
-      setWorkspaceError(error.message || 'Failed to create workspace');
+      setWorkspaceError(error.message || 'Failed to create realm');
     } finally {
       setWorkspaceLoading(false);
     }
@@ -83,10 +83,10 @@ export default function Sidebar({ view, setView }) {
               const workspace = workspaces.find(w => w.id === e.target.value);
               setCurrentWorkspace(workspace);
             }}
-            aria-label="Select workspace"
+            aria-label="Select realm"
           >
             {workspaces.length === 0 ? (
-              <option value="">no workspaces</option>
+              <option value="">no realms</option>
             ) : (
               workspaces.map(workspace => (
                 <option key={workspace.id} value={workspace.id}>
@@ -98,8 +98,8 @@ export default function Sidebar({ view, setView }) {
           <button 
             className="btn btn-icon btn-sm btn-ghost"
             onClick={() => setShowWorkspaceModal(true)}
-            aria-label="Create new workspace"
-            title="Create workspace"
+            aria-label="Create new realm"
+            title="Create realm"
           >
             <span aria-hidden="true">+</span>
           </button>
@@ -107,8 +107,8 @@ export default function Sidebar({ view, setView }) {
             <button 
               className="btn btn-icon btn-sm btn-ghost"
               onClick={() => setShowSettings(true)}
-              aria-label="Workspace settings"
-              title="Workspace settings"
+              aria-label="Realm settings"
+              title="Realm settings"
             >
               <span aria-hidden="true">⚙</span>
             </button>
@@ -239,7 +239,7 @@ export default function Sidebar({ view, setView }) {
           setWorkspaceError('');
         }} role="dialog" aria-modal="true" aria-labelledby="workspace-modal-title">
           <div className="modal" onClick={e => e.stopPropagation()}>
-            <h2 id="workspace-modal-title">Create Workspace</h2>
+            <h2 id="workspace-modal-title">Create Realm</h2>
             <form onSubmit={handleCreateWorkspace}>
               <div className="input-group">
                 <input
@@ -255,7 +255,7 @@ export default function Sidebar({ view, setView }) {
                   aria-describedby={workspaceError ? 'workspace-error' : undefined}
                   aria-invalid={!!workspaceError}
                 />
-                <label htmlFor="workspace-name" className="input-label">Workspace name</label>
+                <label htmlFor="workspace-name" className="input-label">Realm name</label>
               </div>
               {workspaceError && (
                 <div id="workspace-error" className="input-error-message" role="alert" aria-live="polite">

--- a/client/src/components/WorkspaceSettings.jsx
+++ b/client/src/components/WorkspaceSettings.jsx
@@ -81,11 +81,11 @@ export default function WorkspaceSettings({ onClose }) {
       <div className="settings-overlay" onClick={onClose}>
         <div className="settings-modal" onClick={e => e.stopPropagation()}>
           <div className="settings-header">
-            <h2>workspace settings</h2>
+            <h2>realm settings</h2>
             <button className="close-btn" onClick={onClose}>×</button>
           </div>
           <div className="settings-content">
-            <p className="settings-error">only workspace owners can modify settings</p>
+            <p className="settings-error">only realm owners can modify settings</p>
           </div>
         </div>
       </div>
@@ -105,7 +105,7 @@ export default function WorkspaceSettings({ onClose }) {
             <h3>general</h3>
             
             <div className="form-group">
-              <label htmlFor="workspace-name">workspace name</label>
+              <label htmlFor="workspace-name">realm name</label>
               <input
                 id="workspace-name"
                 type="text"


### PR DESCRIPTION
## Summary
- Improved view selector tab design with better spacing and readability
- Renamed "workspaces" to "realms" throughout the application
- Fixed dropdown text color issues in dark themes

## Changes

### View Selector Improvements
- Added proper spacing between tabs (`gap: var(--space-xs)`)
- Changed from flex-fill to fixed-size tabs for better consistency
- Updated text from UPPERCASE to Capitalized for improved readability
- Added horizontal scrolling support for small screens
- Improved hover and active states with rounded corners

### Terminology Update
- Changed all user-facing "workspace" references to "realm"
- Updated labels, placeholders, and error messages
- Maintained internal variable names for backward compatibility

### Dark Theme Fixes
- Fixed workspace/realm dropdown text color in dark and amber themes
- Ensured proper contrast by adding explicit `color: var(--text-primary)`

## Test Plan
- [ ] Verify view selector tabs display correctly with proper spacing
- [ ] Confirm tabs are scrollable on narrow screens
- [ ] Check that all "workspace" text has been updated to "realm" in the UI
- [ ] Test dropdown text visibility in all themes (light, dark, amber)
- [ ] Ensure no functionality is broken by the terminology change

🤖 Generated with [Claude Code](https://claude.ai/code)