### PR TITLE
Add public realm creation feature

### DIFF
--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -23,6 +23,7 @@ export default function Sidebar({ view, setView }) {
   const [showServerModal, setShowServerModal] = useState(false);
   const [showChannelModal, setShowChannelModal] = useState(false);
   const [serverName, setServerName] = useState('');
+  const [serverDescription, setServerDescription] = useState('');
   const [channelName, setChannelName] = useState('');
   const [serverError, setServerError] = useState('');
   const [channelError, setChannelError] = useState('');
@@ -36,6 +37,7 @@ export default function Sidebar({ view, setView }) {
   const [createEncryptedServer, setCreateEncryptedServer] = useState(false);
   const [showServerKeyModal, setShowServerKeyModal] = useState(false);
   const [newServerKey, setNewServerKey] = useState(null);
+  const [createPublicServer, setCreatePublicServer] = useState(false);
   const { setPassword } = useEncryption();
 
   const handleCreateServer = async (e) => {
@@ -43,9 +45,12 @@ export default function Sidebar({ view, setView }) {
     setServerError('');
     setServerLoading(true);
     try {
-      const newServer = await createServer(serverName, '', 'private', createEncryptedServer);
+      const visibility = createPublicServer ? 'public' : 'private';
+      const newServer = await createServer(serverName, serverDescription, visibility, createEncryptedServer);
       setServerName('');
+      setServerDescription('');
       setCreateEncryptedServer(false);
+      setCreatePublicServer(false);
       setShowServerModal(false);
       
       // If encrypted and key was generated, show it to the user
@@ -277,17 +282,47 @@ export default function Sidebar({ view, setView }) {
                 />
                 <label htmlFor="server-name" className="input-label">Realm name</label>
               </div>
+              <div className="input-group">
+                <textarea
+                  id="server-description"
+                  className="input textarea"
+                  placeholder=" "
+                  value={serverDescription}
+                  onChange={(e) => setServerDescription(e.target.value)}
+                  disabled={serverLoading}
+                  rows="3"
+                />
+                <label htmlFor="server-description" className="input-label">Description (optional)</label>
+              </div>
               <div className="checkbox-group">
                 <input
                   type="checkbox"
                   id="server-encrypted"
                   checked={createEncryptedServer}
                   onChange={(e) => setCreateEncryptedServer(e.target.checked)}
-                  disabled={serverLoading}
+                  disabled={serverLoading || createPublicServer}
                 />
                 <label htmlFor="server-encrypted">
                   Create encrypted realm
                   <span className="checkbox-hint">Realm data will be end-to-end encrypted</span>
+                </label>
+              </div>
+              <div className="checkbox-group">
+                <input
+                  type="checkbox"
+                  id="server-public"
+                  checked={createPublicServer}
+                  onChange={(e) => {
+                    setCreatePublicServer(e.target.checked);
+                    if (e.target.checked) {
+                      setCreateEncryptedServer(false);
+                    }
+                  }}
+                  disabled={serverLoading}
+                />
+                <label htmlFor="server-public">
+                  Make realm public
+                  <span className="checkbox-hint">Anyone can find and join this realm</span>
                 </label>
               </div>
               {serverError && (


### PR DESCRIPTION
## Summary
This PR adds the ability to create public realms that can be discovered by other users.

## Features Added

### 1. Public/Private Toggle
- Added checkbox to make realms public when creating
- Public realms appear in the "Find Realms" page
- Clear indication that "Anyone can find and join this realm"

### 2. Description Field
- Added optional description field for realms
- Helps users understand what a realm is about
- Shows in public realm listings

### 3. UI Improvements
- Public realms cannot be encrypted (enforced in UI)
- Better form layout with description textarea
- Proper state management and error handling

## Impact
- Users can now create discoverable public communities
- No more empty "No public realms available" message
- Better discoverability and community building

## Testing
- [x] Create a public realm
- [x] Verify it appears in Find Realms
- [x] Create a private realm
- [x] Verify it doesn't appear in Find Realms
- [x] Add description and verify it shows

🤖 Generated with [Claude Code](https://claude.ai/code)